### PR TITLE
Add spelling suggestions by querying Elasticsearch directly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/composer.lock
+/resources
+/silverstripe-elasticappsearch
+/vendor

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Add the following to your composer.json:
 }
 ```
 
+You will need to add the following environment variables:
+* `APP_SEARCH_ENDPOINT`: This should already be defined if you are using the [silverstripe/silverstripe-search-service](https://github.com/silverstripe/silverstripe-search-service/) module. This is the API endpoint for your Elastic App Search interface.
+* `APP_SEARCH_API_SEARCH_KEY`: This is the public search API key that you've configured in the Credentials section of Elastic App Search. It should begin with `search-`.
+
 Then run the following:
 ```shell script
 cd /path/to/your/project-root
@@ -163,6 +167,85 @@ See [the Elastic documentation](https://www.elastic.co/guide/en/app-search/curre
 
 ### Pagination
 By default, this module automatically handles the pagination of results for you, provided you use the built-in `PaginatedList` class (used by default). However, if you want to override this, you can call `$query->setPagination($pageSize, $pageNum)` to configure it directly.
+
+## Spelling suggestions
+If you want spellcheck (e.g. "Did you mean"), then you'll need to make some changes. Firstly, by default Elastic App Search includes 'typo tolerance' which automatically provides some level of spelling suggestion, however instead of suggesting alternate spelling, it just includes many different words as part of the query. For example, a search for `chanel` might return results for `channel` and `panel` as well. This can be helpful in some circumstances, but also it can easily include many irrelevant results when users accidentally mis-spell a word.
+
+We recommend that you only run a spelling suggestion when you get zero results for a specific query (as it's impossible to tell the difference between helpful and unhelpful results when typo tolerance is enabled).
+
+To do this, you can simply use the following YML fragment. If you don't do this, you are more likely to get _some_ results returned, which means your spelling suggestions will be less useful.
+
+```yml
+SilverStripe\ElasticAppSearch\Query\SearchQuery:
+    enable_typo_tolerance: false
+```
+
+Next, we want to enable querying of the underlying Elasticsearch datastore whenever no search results are found. This can be done automatically when calling `AppSearchService->query()`, or it can be done manually in your own code. Either way, we first require three environment variables to be configured:
+```dotenv
+# The Cloud ID from the Elastic Cloud console. This should start with the name of the deployment, then a colon (:), then a base64-encoded string.
+# Example: test-deployment:c29tZS11cmwtdG8tZWxhc3RpY3NlYXJjaC5leGFtcGxlLmNvbSRyYW5kb20tdXVpZC1zdHJpbmctMSRyYW5kb20tdXVpZC1zdHJpbmctMg==
+ELASTICSEARCH_CLOUD_ID=""
+
+# The API key ID, returned when generating the API key via the Elasticsearch CLI
+ELASTICSEARCH_API_KEY_ID=""
+
+# The API key, returned when generating the API key via the Elasticsearch CLI
+ELASTICSEARCH_API_KEY=""
+```
+
+Then, you will need to use composer to install the `elastic/elasticsearch-php` library. If this is not installed, spellchecking won't occur (but no errors should be thrown).
+
+```shell
+# Confirm the version of Elastic Enterprise Search being used before running this - the verions of all libraries run in lock-step
+composer require "elasticsearch/elasticsearch:^7.11"
+```
+
+Next, you can enable automatic spellcheck when zero results are returned. Alongside enabling it, you need to specify which fields you want to request suggestions from for each internal Elasticsearch index. Index and field names need to be in the internal Elasticsearch format (typically `.ent-search-engine-random-sha` for the index name and `field_name$string` for example for a `text` field in Elastic App Search):
+
+```yml
+SilverStripe\ElasticAppSearch\Service\AppSearchService:
+    # Enable spellchecking by default when zero results are returned by Elastic App Search.
+    enable_spellcheck_on_zero_results: true
+    
+    # Sets the index variant value. If using the silverstripe-search-service module, this must be the same as what you use for that (e.g. `APP_SEARCH_ENGINE_PREFIX`)
+    index_variant: '`SS_ENVIRONMENT_TYPE`'
+
+SilverStripe\ElasticAppSearch\Service\SpellcheckService:
+    # Set the maximum number of spelling suggestions to return. Elasticsearch may return less than this, but if it returns more than only the top N suggestions will be provided to the SearchResult.
+    max_spellcheck_suggestions: 2
+    
+    # Provide the GET query param that needs to be changed when creating links to other spelling suggestions
+    query_param: q
+    
+    # The engine/index and field map for each Elastic App Search you want to provide spellchecking for, where:
+    # - engine_name is the name of the engine (don't include the environment variable part - e.g. just use "content" if your engine name is actually "dev-content"
+    # - internal_index_name is the internal name of the index within Elasticsearch. This typically starts with .ent-search-engine- and then a random SHA.
+    # - fields is an array of internal Elasticsearch fields that should be used to get spelling suggestions from. These can only be taken from text (aka string) fields, and follow the Elastic App Search naming format (e.g. a field in your IndexConfiguration called 'Title' will have a field called 'Title$string' internally within Elasticsearch).
+    spellcheck_suggestion_fields:
+        engine_name:
+            internal_index_name: '.ent-search-engine-random-sha'
+            fields:
+                - "title$string"
+                - "content$string"
+```
+
+Finally, you just need to update your template to include the new spelling suggestions if there are zero results.
+
+```html
+<% if not $SearchResults.Results %>
+    <p>Sorry, we didn't find any search results for your query "$SearchResults.Query".</p>
+    <% if $SearchResults.SpellingSuggestions %>
+        <p>
+            Did you mean:
+            <% loop $SearchResults.SpellingSuggestions %>
+                <a href="$Link" title="Search for '$Suggestion' instead">$Suggestion</a><% if $Last %>?<% else %>, <% end_if %>
+            <% end_loop %>
+        </p>
+    <% end_if %>
+<% end_if %>
+```
+
+Alternatively, if you want to perform your own spellchecking or manipulate the results in a different way, you can query `AppSearchService->getSpellingSuggestions()` directly, passing in a `SearchQuery` object.
 
 ## Simple example of usage
 

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
 
     "require": {
         "elastic/app-search": "^7.9",
-        "silverstripe/framework": "^4"
+        "silverstripe/framework": "^4",
+        "mockery/mockery": "^1.2"
     },
 
     "require-dev": {
@@ -28,5 +29,9 @@
         "psr-4": {
             "SilverStripe\\ElasticAppSearch\\": "silverstripe-elasticappsearch/src"
         }
+    },
+
+    "suggest": {
+        "elasticsearch/elasticsearch": "Allows the use of spellcheck (see silverstripe-elasticappsearch README for details)"
     }
 }

--- a/src/Gateway/ElasticsearchGateway.php
+++ b/src/Gateway/ElasticsearchGateway.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace SilverStripe\ElasticAppSearch\Gateway;
+
+use Elasticsearch\Client;
+use Elasticsearch\ClientBuilder;
+use SilverStripe\Core\Environment;
+
+class ElasticsearchGateway
+{
+    /**
+     * @var Client
+     */
+    protected $client;
+
+    public function search(array $params)
+    {
+        $client = $this->getClient();
+        return $client->search($params);
+    }
+
+    protected function getClient()
+    {
+        if (!$this->client) {
+            $elasticCloudId = Environment::getEnv('ELASTICSEARCH_CLOUD_ID');
+            $apiKeyId = Environment::getEnv('ELASTICSEARCH_API_KEY_ID');
+            $apiKey = Environment::getEnv('ELASTICSEARCH_API_KEY');
+
+            $this->client = ClientBuilder::create()
+                ->setElasticCloudId($elasticCloudId)
+                ->setApiKey($apiKeyId, $apiKey)
+                ->build();
+        }
+
+        return $this->client;
+    }
+}

--- a/src/Service/SearchResult.php
+++ b/src/Service/SearchResult.php
@@ -56,6 +56,11 @@ class SearchResult extends ViewableData
     private $facets;
 
     /**
+     * @var ArrayList A list of spelling suggestions for the given result set, if enabled
+     */
+    private $spellingSuggestions;
+
+    /**
      * @var bool
      */
     private $isPartOfMultiSearch = false;
@@ -117,6 +122,17 @@ class SearchResult extends ViewableData
         }
 
         return ArrayList::create();
+    }
+    
+    public function getSpellingSuggestions(): ?ArrayList
+    {
+        return $this->spellingSuggestions;
+    }
+    
+    public function setSpellingSuggestions(ArrayList $suggestions): self
+    {
+        $this->spellingSuggestions = $suggestions;
+        return $this;
     }
 
     protected function extractResults(array $response): PaginatedList

--- a/src/Service/SpellcheckService.php
+++ b/src/Service/SpellcheckService.php
@@ -1,0 +1,406 @@
+<?php
+
+namespace SilverStripe\ElasticAppSearch\Service;
+
+use Elasticsearch\ClientBuilder;
+use Exception;
+use LogicException;
+use Psr\Log\LoggerInterface;
+use SilverStripe\Control\HTTP;
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Core\Config\Configurable;
+use SilverStripe\Core\Environment;
+use SilverStripe\Core\Extensible;
+use SilverStripe\Core\Injector\Injectable;
+use SilverStripe\ElasticAppSearch\Gateway\ElasticsearchGateway;
+use SilverStripe\ElasticAppSearch\Query\SearchQuery;
+use SilverStripe\ORM\ArrayList;
+use SilverStripe\View\ArrayData;
+
+class SpellcheckService
+{
+    use Injectable;
+    use Extensible;
+    use Configurable;
+
+    /**
+     * @var int The maximum number of spelling suggestions to return. The code will still do all calculations, so
+     * lowering this number will not make the website faster, but it can be used to ensure that you only get a small
+     * number of actual suggestions (so you don't have to do this manually in your template).
+     */
+    private static $max_spellcheck_suggestions = 2;
+
+    /**
+     * @var string The HTTP query param that needs to be changed whenever a spelling suggestion is suggested
+     */
+    private static $query_param = null;
+
+    /**
+     * @var array The suggestion fields to query for each engine/index. See the README for more information on the
+     * required structure of this array.
+     */
+    private static $spellcheck_suggestion_fields = [];
+
+    private static $dependencies = [
+        'elasticsearchGateway' => '%$' . ElasticsearchGateway::class,
+        'appSearchService' => '%$' . AppSearchService::class,
+        'logger' => '%$' . LoggerInterface::class . '.errorhandler',
+    ];
+
+    /**
+     * @var ElasticsearchGateway The Elasticsearch gateway to be used when querying the underlying Elasticsearch store
+     */
+    public $elasticsearchGateway;
+
+    /**
+     * @var AppSearchService The AppSearchService class used to environment-ize engine / index names
+     */
+    public $appSearchService;
+
+    /**
+     * @var LoggerInterface The monolog interface used to handle errors and warnings during searching
+     */
+    public $logger;
+
+    /**
+     * Given a SearchQuery with keywords, split the keyword up by token (word) and query each word for spelling
+     * suggestions individually, then return an ArrayList where each item in the list is an ArrayData containing the
+     * following properties:
+     *   - Link: A fully-qualified URL to the current page with the corrected word replaced in the URL string
+     *   - Suggestion: The new complete phrase (e.g. searching for "chanel partner", Suggestion = "channel partner")
+     *
+     * @param SearchQuery $query The search query that was used to query Elastic App Search
+     * @param string $engineName The engine name to perform the internal lookup on
+     * @param HTTPRequest $request Used as a base to manipulate the URL in order to create the 'Link' values
+     * @return ArrayList|null An ArrayList containing ArrayData elements for each suggestion, or null on error
+     */
+    public function getSpellingSuggestions(SearchQuery $query, string $engineName, HTTPRequest $request): ?ArrayList
+    {
+        try {
+            // Ensure we can extract spelling suggestions from Elasticsearch directly
+            $this->ensureSpellcheckAvailable($engineName);
+
+            // Get suggestion fields to query Elastic on
+            $suggestionConfig = $this->config()->spellcheck_suggestion_fields;
+            $esIndexName = null;
+            $esSuggestionFields = [];
+
+            // Loop over each suggestion field to find the one that matches the requested engine name
+            foreach ($suggestionConfig as $indexName => $suggestionData) {
+                if ($this->appSearchService->environmentizeIndex($indexName) == $engineName) {
+                    // We have the correct engine, so we want to extract the necessary fields and internal name
+                    $esIndexName = $suggestionData['internal_index_name'];
+                    $esSuggestionFields = $suggestionData['fields'];
+                }
+            }
+
+            // Construct a search query for Elasticsearch
+            $searchParams = [
+                'index' => $esIndexName,
+                'body' => [
+                    'suggest' => [
+                        'text' => $query->getQuery(),
+                    ]
+                ]
+            ];
+
+            // Loop over each suggestion field and add it to the $searchParams array
+            foreach ($esSuggestionFields as $fieldName) {
+                $searchParams['body']['suggest'][$fieldName] = [
+                    'term' => [
+                        'field' => $fieldName
+                    ]
+                ];
+            }
+
+            // Attempt to make a connection to Elasticsearch
+            $suggestions = $this->elasticsearchGateway->search($searchParams);
+            $extractedSuggestions = $this->extractPotentialSuggestions($suggestions);
+
+            // Now we have a sorted, flattened list of potential suggestions, and we just need to pick some
+            $selectedSuggestions = $this->selectSuggestions($extractedSuggestions, $query);
+
+            // Now that we've selected some suggestions, create the ArrayList
+            $list = ArrayList::create();
+
+            foreach ($selectedSuggestions as $suggestion) {
+                $data = ArrayData::create([
+                    'Suggestion' => $suggestion,
+                    'Link' => HTTP::setGetVar($this->config()->query_param, $suggestion, $request->getURL(true))
+                ]);
+
+                $list->push($data);
+            }
+
+            return $list;
+        } catch (Exception $e) {
+            // Soft-fail - log the error but do not fail the entire request
+            $this->logger->error(
+                sprintf("Couldn't find spelling suggestions for %s: %s", $query->getQuery(), $e->getMessage())
+            );
+        }
+
+        return null;
+    }
+
+    /**
+     * This method extracts a unique list of spelling suggestions for each original word in the search query.
+     *
+     * The returned array will look something like this:
+     * [
+     *     'original_word_1' => [
+     *         'suggestion_1',
+     *         'suggestion_2',
+     *         'suggestion_3'
+     *     ],
+     *     'original_word_2' => [
+     *         'original_word_2'
+     *     ]
+     * ]
+     *
+     * The original words will be ordered based on their original position in the original query string, so you can put
+     * together a search suggestion by combining 'suggestion_1 + original_word_2' in this case.
+     *
+     * Note that if the original word is deemed to be spelt properly, no suggestions will be included for it, therefore
+     * we insert the original word as the most likely result instead, so that later generation of suggestions is easier.
+     *
+     * @param array $suggestions The full API response from Elasticsearch (including the 'suggest' key).
+     * @return array
+     */
+    protected function extractPotentialSuggestions(array $suggestions): array
+    {
+        // Ensure suggestions exist in the response
+        if (!array_key_exists('suggest', $suggestions)) {
+            return [];
+        }
+
+        $suggestions = $this->flattenSuggestions($suggestions);
+        return $suggestions;
+    }
+
+    /**
+     * Flattens a full Elasticsearch response containing the 'suggest' key down into a single array of suggestions. This
+     * combines the individual field results into a single list for each word. If the same suggested word occurs in
+     * multiple lists, then the one with the highest score will win. Once all suggested words are found, we re-sort the
+     * list based on score (so that the first suggested word is the one with the highest score value).
+     *
+     * @param array $suggestions
+     * @return array
+     */
+    protected function flattenSuggestions(array $suggestions): array
+    {
+        $potentialSuggestions = [];
+
+        if (!array_key_exists('suggest', $suggestions)) {
+            return [];
+        }
+
+        // $words is an array containing multiple arrays - one array for each word in the original search query
+        foreach ($suggestions['suggest'] as $fieldName => $words) {
+            foreach ($words as $word) {
+                // First ensure we have a valid word suggestion, and skip if we don't have all the data we need
+                if (!isset($word['text']) || !isset($word['options']) || !is_array($word['options'])) {
+                    continue;
+                }
+
+                // If we don't already have an entry in $potentialSuggestions for the original word, create one
+                if (!isset($potentialSuggestions[$word['text']])) {
+                    $potentialSuggestions[$word['text']] = [];
+                }
+
+                // If there isn't a suggested word for this original word, make sure we insert the original word as a
+                // suggestion with a score of 1 provided it's not already there. This makes subsequent processing easier.
+                if (sizeof($word['options']) <= 0) {
+                    // Make sure it's not already in the suggestion list
+                    $inserted = false;
+
+                    foreach ($potentialSuggestions[$word['text']] as $existingOption) {
+                        if ($existingOption['text'] === $word['text']) {
+                            $inserted = true;
+                            break;
+                        }
+                    }
+
+                    if (!$inserted) {
+                        $potentialSuggestions[$word['text']][] = [
+                            'text' => $word['text'],
+                            'score' => 1
+                        ];
+                    }
+                } else {
+                    // Otherwise, there's at least one suggested word to replace the original word. Check through all
+                    // existing suggestions to see if this suggestion has already been made. If it has, check the score
+                    // and keep only the higher score. If it hasn't, then insert it as another suggestion.
+                    foreach ($word['options'] as $option) {
+                        $inserted = false;
+
+                        // Loop over existing potential suggestions to find a match
+                        foreach ($potentialSuggestions[$word['text']] as $existingOption) {
+                            if ($existingOption['text'] === $option['text']) {
+                                // We already have this word as a suggestion, so compare and overwrite if it's higher
+                                if ($option['score'] > $existingOption['score']) {
+                                    $existingOption['score'] = $option['score'];
+                                }
+
+                                // Mark as inserted so we don't insert again
+                                $inserted = true;
+                                break;
+                            }
+                        }
+
+                        if (!$inserted) {
+                            // We haven't see this suggestion before, so add it to the end of the list (we'll sort based
+                            // on score later)
+                            $potentialSuggestions[$word['text']][] = [
+                                'text' => $option['text'],
+                                'score' => $option['score']
+                            ];
+                        }
+                    }
+                }
+            }
+        }
+
+        // Finally, sort the suggestions for each word based on the suggestion scores
+        $potentialSuggestions = $this->sortSuggestions($potentialSuggestions);
+        return $potentialSuggestions;
+    }
+
+    /**
+     * Takes a flattened array of spelling suggestions for each original word in the search query and sorts the
+     * suggestions based on their internal Elasticsearch score.
+     *
+     * Scores are from 0 to 1, with 1 being the best suggestion.
+     *
+     * @param array $suggestions An unsorted multi-dimensional array of word suggestions
+     * @return array A sorted array
+     */
+    protected function sortSuggestions(array $suggestions): array
+    {
+        $sortFunc = function(array $a, array $b) {
+            if ($a['score'] === $b['score']) {
+                return 0;
+            } elseif ($a['score'] < $b['score']) {
+                return 1;
+            } else {
+                return -1;
+            }
+        };
+
+        foreach ($suggestions as $originalWord => $list) {
+            usort($list, $sortFunc);
+            $suggestions[$originalWord] = $list;
+        }
+
+        return $suggestions;
+    }
+
+    /**
+     * From the flattened, sorted list of suggestions, select up to the maximum number of suggestions and return then.
+     *
+     * @param array $extractedSuggestions
+     * @param SearchQuery $query
+     * @return array A single-dimensional array of full query strings, with the original word swapped for the suggestion
+     */
+    protected function selectSuggestions(array $extractedSuggestions, SearchQuery $query): array
+    {
+        $maxNumSuggestions = $this->config()->max_spellcheck_suggestions;
+        $selectedSuggestions = [];
+        $originalQuery = $query->getQuery();
+
+        foreach ($extractedSuggestions as $originalWord => $replacementSuggestions) {
+            foreach ($replacementSuggestions as $replacement) {
+                $newSuggestion = str_replace($originalWord, $replacement['text'], $originalQuery);
+
+                // Make sure we don't just suggest the same query the user just entered
+                if ($newSuggestion != $originalQuery) {
+                    $selectedSuggestions[] = $newSuggestion;
+                }
+
+                // If we've got enough suggestions now, break out of both inner and outer loops to return the selections
+                if (sizeof($selectedSuggestions) >= $maxNumSuggestions) {
+                    break 2;
+                }
+            }
+        }
+
+        return $selectedSuggestions;
+    }
+
+    /**
+     * Ensures Elasticsearch should be reachable and ready for querying, by checking that:
+     * - All necessary environment variables are set
+     * - That the elasticsearch/elasticsearch Composer library is installed
+     * - That we have at least some Elasticsearch fields to ask for suggestions within
+     *
+     * This does not attempt to make a connection to Elasticsearch at all.
+     *
+     * @param string $requestedEngineName The Elastic App Search engine name that we expect to find mapped
+     * @throws LogicException When any of the above conditions are not satisfied
+     */
+    private function ensureSpellcheckAvailable($requestedEngineName)
+    {
+        if (!Environment::getEnv('ELASTICSEARCH_CLOUD_ID')) {
+            throw new LogicException('Required environment variable ELASTICSEARCH_CLOUD_ID not configured.');
+        }
+
+        if (strpos(Environment::getEnv('ELASTICSEARCH_CLOUD_ID'), ':') === false) {
+            throw new LogicException('ELASTICSEARCH_CLOUD_ID env var is invalid - it must contain a colon (:).');
+        }
+
+        if (!Environment::getEnv('ELASTICSEARCH_API_KEY_ID')) {
+            throw new LogicException('Required environment variable ELASTICSEARCH_API_KEY_ID not configured.');
+        }
+
+        if (!Environment::getEnv('ELASTICSEARCH_API_KEY')) {
+            throw new LogicException('Required environment variable ELASTICSEARCH_API_KEY not configured.');
+        }
+
+        if (!class_exists(ClientBuilder::class)) {
+            throw new LogicException('The elasticsearch/elasticsearch Composer library is not installed.');
+        }
+
+        // Ensure we have a query param to adjust
+        if (!$this->config()->query_param) {
+            throw new LogicException('You need to set query_param in YML configuration.');
+        }
+
+        // Ensure we have at least one field in Elasticsearch to check for suggestions within
+        $suggestionFields = $this->config()->spellcheck_suggestion_fields;
+        $engineNameFound = false;
+
+        if (!is_array($suggestionFields) || sizeof($suggestionFields) == 0) {
+            throw new LogicException('You must define at least one field in YML for spellcheck_suggestion_fields.');
+        }
+
+        foreach ($suggestionFields as $engineName => $data) {
+            if (!array_key_exists('internal_index_name', $data)) {
+                throw new LogicException(sprintf('You must define internal_index_name for the engine %s', $engineName));
+            }
+
+            if (!array_key_exists('fields', $data) || !is_array($data['fields'])) {
+                throw new LogicException(sprintf('You must define the fields array for the engine %s', $engineName));
+            }
+
+            // Follow the same 'environmentalize' pattern that the silverstripe-search-service module does to make sure
+            // the engine name matches
+            $engineName = $this->appSearchService->environmentizeIndex($engineName);
+
+            if ($engineName === $requestedEngineName) {
+                $engineNameFound = true;
+            }
+        }
+
+        // If we haven't found the engine name, then we know that the engine we are trying to query doesn't exist in our
+        // loopup table, so we don't know what the internal_index_name is - this is a hard failure
+        if (!$engineNameFound) {
+            $error = sprintf(
+                'You requested spellcheck suggestions from the %s engine but have not included that in the'
+                . ' configuration for spellcheck_suggestion_fields',
+                $requestedEngineName
+            );
+
+            throw new LogicException($error);
+        }
+    }
+}

--- a/tests/Service/SpellcheckServiceTest.php
+++ b/tests/Service/SpellcheckServiceTest.php
@@ -1,0 +1,360 @@
+<?php
+
+namespace SilverStripe\ElasticAppSearch\Tests\Service;
+
+use Mockery;
+use ReflectionMethod;
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Core\Config\Config;
+use SilverStripe\Core\Environment;
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\ElasticAppSearch\Gateway\ElasticsearchGateway;
+use SilverStripe\ElasticAppSearch\Query\SearchQuery;
+use SilverStripe\ElasticAppSearch\Service\AppSearchService;
+use SilverStripe\ElasticAppSearch\Service\SpellcheckService;
+use SilverStripe\ORM\ArrayList;
+
+class SpellcheckServiceTest extends SapphireTest
+{
+    public function testGetSpellingSuggestions()
+    {
+        $query = new SearchQuery();
+        $query->setQuery('originalWord1 originalWord2');
+        $engineName = 'test';
+
+        $request = new HTTPRequest('GET', '/search', ['q' => 'originalWord1 originalWord2']);
+
+        $service = $this->configureSpellcheckServiceMock();
+
+        // Get a response from our mock Elasticsearch gateway
+        $response = $service->getSpellingSuggestions($query, $engineName, $request);
+
+        $this->assertTrue($response instanceof ArrayList);
+        $this->assertSame(2, $response->count());
+
+        // Ensure the first suggestion is correct
+        $this->assertSame('suggestion1 originalWord2', $response->offsetGet(0)->Suggestion);
+        $this->assertSame('/search?q=suggestion1+originalWord2', $response->offsetGet(0)->Link);
+
+        // Ensure the second suggestion is correct
+        $this->assertSame('suggestion2 originalWord2', $response->offsetGet(1)->Suggestion);
+        $this->assertSame('/search?q=suggestion2+originalWord2', $response->offsetGet(1)->Link);
+
+        // After modifying the query param, test that links still get re-written correctly
+        Config::modify()->set(SpellcheckService::class, 'query_param', 'keywords');
+        $newRequest = new HTTPRequest('GET', '/search', ['keywords' => 'originalWord1 originalWord2']);
+        $response = $service->getSpellingSuggestions($query, $engineName, $newRequest);
+
+        $this->assertSame('/search?keywords=suggestion1+originalWord2', $response->offsetGet(0)->Link);
+        $this->assertSame('/search?keywords=suggestion2+originalWord2', $response->offsetGet(1)->Link);
+
+        // If the maximum number of suggestions is increased, ensure we get more suggestions
+        Config::modify()->set(SpellcheckService::class, 'query_param', 'q');
+        Config::modify()->set(SpellcheckService::class, 'max_spellcheck_suggestions', 10);
+        $response = $service->getSpellingSuggestions($query, $engineName, $request);
+
+        $this->assertSame(9, $response->count());
+
+        $this->assertSame('suggestion1 originalWord2', $response->offsetGet(0)->Suggestion);
+        $this->assertSame('suggestion2 originalWord2', $response->offsetGet(1)->Suggestion);
+        $this->assertSame('suggestion3 originalWord2', $response->offsetGet(2)->Suggestion);
+        $this->assertSame('suggestion4 originalWord2', $response->offsetGet(3)->Suggestion);
+        $this->assertSame('suggestion5 originalWord2', $response->offsetGet(4)->Suggestion);
+        $this->assertSame('suggestion6 originalWord2', $response->offsetGet(5)->Suggestion);
+        $this->assertSame('originalWord1 suggestion1', $response->offsetGet(6)->Suggestion);
+        $this->assertSame('originalWord1 suggestion2', $response->offsetGet(7)->Suggestion);
+        $this->assertSame('originalWord1 suggestion3', $response->offsetGet(8)->Suggestion);
+
+        $this->assertSame('/search?q=suggestion1+originalWord2', $response->offsetGet(0)->Link);
+        $this->assertSame('/search?q=suggestion2+originalWord2', $response->offsetGet(1)->Link);
+        $this->assertSame('/search?q=suggestion3+originalWord2', $response->offsetGet(2)->Link);
+        $this->assertSame('/search?q=suggestion4+originalWord2', $response->offsetGet(3)->Link);
+        $this->assertSame('/search?q=suggestion5+originalWord2', $response->offsetGet(4)->Link);
+        $this->assertSame('/search?q=suggestion6+originalWord2', $response->offsetGet(5)->Link);
+        $this->assertSame('/search?q=originalWord1+suggestion1', $response->offsetGet(6)->Link);
+        $this->assertSame('/search?q=originalWord1+suggestion2', $response->offsetGet(7)->Link);
+        $this->assertSame('/search?q=originalWord1+suggestion3', $response->offsetGet(8)->Link);
+    }
+
+    public function testExtractPotentialSuggestions()
+    {
+        // This is a very simple function, we just have to test that it works correctly when we pass an expected array
+        // and fails gracefully when we pass an array without key features present.
+        // The bulk of the processing is tested in other tests below
+        $service = Injector::inst()->get(SpellcheckService::class);
+        $method = new ReflectionMethod(SpellcheckService::class, 'extractPotentialSuggestions');
+        $method->setAccessible(true);
+
+        // With an invalid input, we expect a blank array response
+        $this->assertSame([], $method->invoke($service, []));
+        $this->assertSame([], $method->invoke($service, ['invalid_value']));
+        $this->assertSame([], $method->invoke($service, ['invalid_array_key' => 'invalid_value']));
+    }
+
+    public function testFlattenSuggestions()
+    {
+        $service = Injector::inst()->get(SpellcheckService::class);
+        $method = new ReflectionMethod(SpellcheckService::class, 'flattenSuggestions');
+        $method->setAccessible(true);
+
+        $esResponse = $this->getMockElasticsearchResponse();
+        $flattenedSuggestions = $method->invoke($service, $esResponse);
+
+        $this->assertSame(2, sizeof($flattenedSuggestions));
+        $this->assertArrayHasKey('originalWord1', $flattenedSuggestions);
+        $this->assertArrayHasKey('originalWord2', $flattenedSuggestions);
+
+        // Ensure suggestions that exist in multiple fields are merged into a single suggestion
+        $this->assertSame(6, sizeof($flattenedSuggestions['originalWord1']));
+        $this->assertSame(4, sizeof($flattenedSuggestions['originalWord2'])); // 3 suggestions plus the original word
+
+        // Assert first suggestion for originalWord2 is the original word, it should have been inserted with score = 1
+        $this->assertSame('originalWord2', $flattenedSuggestions['originalWord2'][0]['text']);
+        $this->assertSame(1, $flattenedSuggestions['originalWord2'][0]['score']);
+
+        // Flattened suggestions are also sorted, so we can double-check that sorting works across multiple fields here
+        $this->assertSame('suggestion1', $flattenedSuggestions['originalWord1'][0]['text']);
+        $this->assertSame('suggestion2', $flattenedSuggestions['originalWord1'][1]['text']);
+        $this->assertSame('suggestion3', $flattenedSuggestions['originalWord1'][2]['text']);
+        $this->assertSame('suggestion4', $flattenedSuggestions['originalWord1'][3]['text']);
+        $this->assertSame('suggestion5', $flattenedSuggestions['originalWord1'][4]['text']);
+        $this->assertSame('suggestion6', $flattenedSuggestions['originalWord1'][5]['text']);
+
+        // Ensure that scores are overwritten when higher in a subsequent field
+        $this->assertSame(1, $flattenedSuggestions['originalWord1'][0]['score']);
+        $this->assertSame(0.75, $flattenedSuggestions['originalWord1'][1]['score']);
+        $this->assertSame(0.65, $flattenedSuggestions['originalWord1'][2]['score']);
+        $this->assertSame(0.25, $flattenedSuggestions['originalWord1'][3]['score']);
+        $this->assertSame(0.15, $flattenedSuggestions['originalWord1'][4]['score']);
+        $this->assertSame(0.10, $flattenedSuggestions['originalWord1'][5]['score']);
+
+        // Same checks for originalWord2
+        $this->assertSame('originalWord2', $flattenedSuggestions['originalWord2'][0]['text']);
+        $this->assertSame('suggestion1', $flattenedSuggestions['originalWord2'][1]['text']);
+        $this->assertSame('suggestion2', $flattenedSuggestions['originalWord2'][2]['text']);
+        $this->assertSame('suggestion3', $flattenedSuggestions['originalWord2'][3]['text']);
+
+        // Ensure that scores work for a simpler suggestion set
+        $this->assertSame(1, $flattenedSuggestions['originalWord2'][0]['score']);
+        $this->assertSame(0.90, $flattenedSuggestions['originalWord2'][1]['score']);
+        $this->assertSame(0.80, $flattenedSuggestions['originalWord2'][2]['score']);
+        $this->assertSame(0.20, $flattenedSuggestions['originalWord2'][3]['score']);
+    }
+
+    public function testSortSuggestions()
+    {
+        $service = Injector::inst()->get(SpellcheckService::class);
+        $method = new ReflectionMethod(SpellcheckService::class, 'sortSuggestions');
+        $method->setAccessible(true);
+
+        $suggestions = [
+            'originalWord1' => [
+                // The value of `text` here indicates the order we expect to see the sorted results in
+                [ 'text' => 'suggestion5', 'score' => 0 ],
+                [ 'text' => 'suggestion2', 'score' => 0.50 ],
+                [ 'text' => 'suggestion4', 'score' => 0.25 ],
+                [ 'text' => 'suggestion1', 'score' => 1 ],
+                [ 'text' => 'suggestion3', 'score' => 0.251 ]
+            ],
+
+            'originalWord2' => [
+                [ 'text' => 'suggestion6', 'score' => 1 ],
+                [ 'text' => 'suggestion8', 'score' => 0.2 ],
+                [ 'text' => 'suggestion7', 'score' => 0.75 ],
+            ],
+
+            'originalWord3' => [],
+
+            'originalWord4' => [
+                [ 'text' => 'suggestion9', 'score' => 0.5 ]
+            ]
+        ];
+
+        $sortedSuggestions = $method->invoke($service, $suggestions);
+
+        $this->assertSame(4, sizeof($sortedSuggestions)); // Four original words
+        $this->assertSame(5, sizeof($sortedSuggestions['originalWord1'])); // Still 5 suggestions for word1
+        $this->assertSame(3, sizeof($sortedSuggestions['originalWord2'])); // And 3 suggestions for word2
+        $this->assertSame(0, sizeof($sortedSuggestions['originalWord3'])); // Still 0 suggestions for word3
+        $this->assertSame(1, sizeof($sortedSuggestions['originalWord4'])); // And 1 suggestion for word4
+
+        $this->assertSame('suggestion1', $sortedSuggestions['originalWord1'][0]['text']);
+        $this->assertSame('suggestion2', $sortedSuggestions['originalWord1'][1]['text']);
+        $this->assertSame('suggestion3', $sortedSuggestions['originalWord1'][2]['text']);
+        $this->assertSame('suggestion4', $sortedSuggestions['originalWord1'][3]['text']);
+        $this->assertSame('suggestion5', $sortedSuggestions['originalWord1'][4]['text']);
+
+        $this->assertSame('suggestion6', $sortedSuggestions['originalWord2'][0]['text']);
+        $this->assertSame('suggestion7', $sortedSuggestions['originalWord2'][1]['text']);
+        $this->assertSame('suggestion8', $sortedSuggestions['originalWord2'][2]['text']);
+
+        $this->assertSame('suggestion9', $sortedSuggestions['originalWord4'][0]['text']);
+    }
+
+    public function testSelectSuggestions()
+    {
+        $service = Injector::inst()->get(SpellcheckService::class);
+        $method = new ReflectionMethod(SpellcheckService::class, 'selectSuggestions');
+        $method->setAccessible(true);
+
+        $searchQuery = new SearchQuery();
+        $searchQuery->setQuery('originalWord1 originalWord2');
+
+        $mockResults = [
+            'originalWord1' => [
+                [
+                    'text' => 'suggestion1',
+                    'score' => 1
+                ],
+                [
+                    'text' => 'suggestion2',
+                    'score' => 0.75
+                ]
+            ],
+
+            'originalWord2' => [
+                [
+                    'text' => 'suggestion3',
+                    'score' => 1
+                ]
+            ]
+        ];
+
+        // Test that we get a single suggestion back that modifies originalWord1 by default
+        Config::modify()->set(SpellcheckService::class, 'max_spellcheck_suggestions', 1);
+        $selectedSuggestions = $method->invoke($service, $mockResults, $searchQuery);
+        $this->assertSame(1, sizeof($selectedSuggestions));
+        $this->assertSame('suggestion1 originalWord2', $selectedSuggestions[0]);
+
+        // Test that we get two suggestions back for originalWord1 when we increase the max
+        Config::modify()->set(SpellcheckService::class, 'max_spellcheck_suggestions', 2);
+        $selectedSuggestions = $method->invoke($service, $mockResults, $searchQuery);
+        $this->assertSame(2, sizeof($selectedSuggestions));
+        $this->assertSame('suggestion1 originalWord2', $selectedSuggestions[0]);
+        $this->assertSame('suggestion2 originalWord2', $selectedSuggestions[1]);
+
+        // Test that we replace the second word if there aren't enough suggestions for the first word
+        Config::modify()->set(SpellcheckService::class, 'max_spellcheck_suggestions', 3);
+        $selectedSuggestions = $method->invoke($service, $mockResults, $searchQuery);
+        $this->assertSame(3, sizeof($selectedSuggestions));
+        $this->assertSame('suggestion1 originalWord2', $selectedSuggestions[0]);
+        $this->assertSame('suggestion2 originalWord2', $selectedSuggestions[1]);
+        $this->assertSame('originalWord1 suggestion3', $selectedSuggestions[2]);
+
+        // Finally, test that the max number being larger than our total suggestions doesn't break anything
+        Config::modify()->set(SpellcheckService::class, 'max_spellcheck_suggestions', 500);
+        $selectedSuggestions = $method->invoke($service, $mockResults, $searchQuery);
+        $this->assertSame(3, sizeof($selectedSuggestions));
+    }
+
+    private function getMockElasticsearchResponse()
+    {
+        return [
+            'took' => 1,
+            'timed_out' => null,
+            'hits' => [],
+            '_shards' => [],
+            'suggest' => [
+                'field1' => [
+                    [
+                        'text' => 'originalWord1',
+                        'options' => [
+                            [ 'text' => 'suggestion1', 'score' => 1 ],
+                            [ 'text' => 'suggestion3', 'score' => 0.5 ],
+                            [ 'text' => 'suggestion4', 'score' => 0.25 ],
+                            [ 'text' => 'suggestion2', 'score' => 0.75 ]
+                        ]
+                    ],
+
+                    [
+                        'text' => 'originalWord2',
+                        'options' => [
+                            [ 'text' => 'suggestion1', 'score' => 0.90 ], // Should not be merged with above
+                            [ 'text' => 'suggestion3', 'score' => 0.20 ],
+                            [ 'text' => 'suggestion2', 'score' => 0.80 ], // Should not be merged with above
+                        ]
+                    ]
+                ],
+
+                'field2' => [
+                    [
+                        'text' => 'originalWord1',
+                        'options' => [
+                            [ 'text' => 'suggestion1', 'score' => 0.25 ], // Lower score than field1->suggestion1
+                            [ 'text' => 'suggestion3', 'score' => 0.65 ], // Higher score than field1->suggestion3
+                            [ 'text' => 'suggestion5', 'score' => 0.15 ],
+                            [ 'text' => 'suggestion6', 'score' => 0.10 ],
+                        ]
+                    ],
+                    [
+                        'text' => 'originalWord2',
+                        'options' => [] // Implying that the original word is correctly spelled in this field
+                    ]
+                ]
+            ]
+        ];
+    }
+
+    private function configureSpellcheckServiceMock()
+    {
+        // Setup ElasticsearchGateway mock
+        $gatewayMock = Mockery::mock(ElasticsearchGateway::class);
+        $gatewayMock
+            ->shouldReceive('search')
+            ->withArgs([
+                [
+                    'index' => '.ent-search-engine-abc123thisisahash',
+                    'body' => [
+                        'suggest' => [
+                            'text' => 'originalWord1 originalWord2',
+                            'field1' => [
+                                'term' => [
+                                    'field' => 'field1'
+                                ]
+                            ],
+                            'field2' => [
+                                'term' => [
+                                    'field' => 'field2'
+                                ]
+                            ]
+                        ]
+                    ]
+                ]
+            ])
+            ->andReturn($this->getMockElasticsearchResponse());
+
+        // Setup AppSearchService mock
+        $appSearchServiceMock = Mockery::mock(AppSearchService::class);
+        $appSearchServiceMock
+            ->shouldReceive('environmentizeIndex')
+            ->withArgs(['test']) // Engine name from YML config fragment below
+            ->andReturn('test'); // 'Full' engine name (same as input in this case)
+
+        // Catch the call to ensureSpellcheckAvailable and disable it (don't run original method as we don't care if
+        // things aren't configured properly)
+        /** @var SpellcheckService $service */
+        $service = Mockery::mock(SpellcheckService::class . '[ensureSpellcheckAvailable]')
+            ->shouldAllowMockingProtectedMethods();
+
+        $service->shouldReceive('ensureSpellcheckAvailable');
+
+        $service
+            ->setElasticsearchGateway($gatewayMock)
+            ->setAppSearchService($appSearchServiceMock);
+
+        Config::modify()
+            ->set(SpellcheckService::class, 'query_param', 'q')
+            ->set(SpellcheckService::class, 'spellcheck_suggestion_fields', [
+                'test' => [
+                    'internal_index_name' => '.ent-search-engine-abc123thisisahash',
+                    'fields' => [
+                        'field1',
+                        'field2'
+                    ]
+                ]
+            ]);
+
+        return $service;
+    }
+}


### PR DESCRIPTION
- Add new ElasticsearchGateway to query Elasticsearch
- Add new YML config for enabling or disabling typo tolerance in Elastic App Search
- Ensure SearchQuery forces typo tolerance off if disabled
- If we enable spellcheck suggestions, add these to SerachResults
- Create new SpellcheckService
- Add documentation to README