### PR TITLE
FIX: Missed one place causing suggestions to not get included

### DIFF
--- a/src/Service/SpellcheckService.php
+++ b/src/Service/SpellcheckService.php
@@ -321,7 +321,7 @@ class SpellcheckService
     {
         $maxNumSuggestions = $this->config()->max_spellcheck_suggestions;
         $selectedSuggestions = [];
-        $originalQuery = $query->getQuery();
+        $originalQuery = mb_strtolower($query->getQuery());
 
         foreach ($extractedSuggestions as $originalWord => $replacementSuggestions) {
             foreach ($replacementSuggestions as $replacement) {


### PR DESCRIPTION
Relates to #12, which didn't quite fix the original issue (it would find suggestions, but wouldn't replace them in the suggestion text, leading to zero suggestions being returned).

Not sure how I missed this, self-merging as it's a minor change that doesn't affect anything.