### PR TITLE
Check not null for snippet return

### DIFF
--- a/src/Service/SearchResult.php
+++ b/src/Service/SearchResult.php
@@ -213,7 +213,7 @@ class SearchResult extends ViewableData
                 // Skip known fields that we don't care about checking for snippet data
                 if (in_array($resultField, ['_meta', 'id', 'record_base_class', 'record_id'])) continue;
 
-                if (is_array($fieldValues) && array_key_exists('snippet', $fieldValues)) {
+                if (is_array($fieldValues) && array_key_exists('snippet', $fieldValues) && $fieldValues['snippet'] !== null) {
                     $snippets[$resultField] = DBField::create_field('HTMLVarchar', $fieldValues['snippet']);
                 }
             }


### PR DESCRIPTION
Elastic will return a `null` value if the term is not found in the requested snippet field: 

https://www.elastic.co/guide/en/app-search/current/result-fields-highlights.html#result-fields-highlights-snippet-result-field

This prevents us instantiating empty DB fields