### PR TITLE
ENH: Update `getSortForArray` method visibility to public

### DIFF
--- a/src/Query/SearchQuery.php
+++ b/src/Query/SearchQuery.php
@@ -119,7 +119,7 @@ class SearchQuery
             "it", "no", "not", "of", "on", "or", "such", "that", "the", "their", "then", "there",
             "these", "they", "this", "to", "was", "will", "with"
         ];
-        
+
         foreach (explode(' ', $keywordString) as $keyword) {
             $prefix = '+';
 
@@ -348,7 +348,7 @@ class SearchQuery
         return $searchFields;
     }
 
-    private function getSortForArray(): ?array
+    public function getSortForArray(): ?array
     {
         $sort = null;
 


### PR DESCRIPTION
- To provide accessor to `sort` property and check if the current SearchQuery object has an existing sort applied to it
- It is branched-off the current tag `0.9.6` so we could still use this feature branch for PHP 7.x