### PR TITLE
Fix spell checking for Elastic 8 libraries

### DIFF
--- a/src/Gateway/ElasticsearchGateway.php
+++ b/src/Gateway/ElasticsearchGateway.php
@@ -27,9 +27,7 @@ class ElasticsearchGateway
             $apiKeyId = Environment::getEnv('ELASTICSEARCH_API_KEY_ID');
             $apiKey = Environment::getEnv('ELASTICSEARCH_API_KEY');
 
-            // Handle differences between v7 and v8 of the elastic php client module:
-            // - Different namespaces
-            // - Params for setApiKey reversed
+            // Handle namespace and setApiKey changes made in Version 8 of the elastic php client module:
             if (class_exists('Elastic\Elasticsearch\ClientBuilder')) {
                 $this->client = ClientBuilder::create()
                     ->setElasticCloudId($elasticCloudId)

--- a/src/Service/SpellcheckService.php
+++ b/src/Service/SpellcheckService.php
@@ -2,8 +2,8 @@
 
 namespace SilverStripe\ElasticAppSearch\Service;
 
-use Elasticsearch\ClientBuilder as ClientBuilderV7;
-use Elastic\Elasticsearch\ClientBuilder as ClientBuilderV8;
+use Elasticsearch\ClientBuilder as ClientBuilderLegacy;
+use Elastic\Elasticsearch\ClientBuilder as ClientBuilder;
 use Elastic\Elasticsearch\Response\Elasticsearch;
 use Exception;
 use LogicException;
@@ -378,7 +378,7 @@ class SpellcheckService
             throw new LogicException('Required environment variable ELASTICSEARCH_API_KEY not configured.');
         }
 
-        if (!class_exists(ClientBuilderV7::class) && !class_exists(ClientBuilderV8::class)) {
+        if (!class_exists(ClientBuilderLegacy::class) && !class_exists(ClientBuilder::class)) {
             throw new LogicException('The elasticsearch/elasticsearch Composer library is not installed.');
         }
 


### PR DESCRIPTION
These changes are to get spell checking functionality with Elastic 8.10.0, where version [8.10.0 of the elasticsearch php client module](https://github.com/elastic/elasticsearch-php/tree/8.10/src) has been installed.

With the above version of elasticsearch-php installed there were some issues in connecting to the client:
- The namespace for the `ClientBuilder` class has changed so I have added a check to build the client appropriate to the version of php client installed.
- The key and id params appear to be the wrong way round for the [setApiKey](https://github.com/elastic/elasticsearch-php/blob/main/src/ClientBuilder.php#L229) method, so reversed those for the V8 client builder.
