### PR TITLE
Ensure only framework 4.13 is the limit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,9 @@
     "keywords": ["SilverStripe", "SilverStripe CMS", "Elastic", "Elastic App Search"],
 
     "require": {
-		"php": "^7.4 || ^8.0",
+		"php": "^8.0",
         "silverstripe-terraformers/app-search-php-8": "^7.14",
-        "silverstripe/framework": "^4",
+        "silverstripe/framework": "^4.13",
         "mockery/mockery": "^1.6.5"
     },
 
@@ -39,7 +39,8 @@
     "config": {
         "allow-plugins": {
             "composer/installers": true,
-            "silverstripe/vendor-plugin": true
+            "silverstripe/vendor-plugin": true,
+            "php-http/discovery": true
         }
     }
 }


### PR DESCRIPTION
Version 1.1.2 make use of method exists in CMS 4.13
https://github.com/silverstripeltd/silverstripe-elasticappsearch/commit/63f2198a536b298101432a93020f597eb473b9d1#diff-607677692b8d3b6b6a6c735ccc7b0c18036c0a426dbd859efbc241c8aebb0f2dR60