### PR TITLE
Add elastic limit checks for pagination

### DIFF
--- a/tests/Service/SearchResultTest.php
+++ b/tests/Service/SearchResultTest.php
@@ -140,7 +140,6 @@ class SearchResultTest extends SapphireTest
         $paginatedResults = $result->getResults();
         $this->assertEquals(100, $paginatedResults->TotalPages());
         $this->assertEquals(1000, $paginatedResults->TotalItems());
-        $this->assertEquals(10000, $result->getActualResultCount());
     }
 
     private function getValidResponseFromBase(?array $toMerge = null, $total_results = 10, $total_pages = 1): array


### PR DESCRIPTION
Addresses #27 

# Description
Elastic has limits on the number of results that can be handled by a single query.
Most of the detail for this is contained in #27 but essentially, this PR adds these limits to the search pagination.

# Test notes

- Manual testing of this would involve setting up a search environment where you perform a broad search to match more than 100 pages of results (so if 10 items per page, more than a 1000 results).
- Without this fix Elastic will return an error response if an attempt is made to return page 101 and above.
- With this fix, the paginated results returned will have a maximum of 100 pages.

