### PR TITLE
WIP: Add the ability to define boosts as part of a query.

### DIFF
--- a/src/Query/SearchQuery.php
+++ b/src/Query/SearchQuery.php
@@ -28,6 +28,11 @@ class SearchQuery
     /**
      * @var stdClass
      */
+    private $rawBoosts;
+
+    /**
+     * @var stdClass
+     */
     private $rawFacets;
 
     /**
@@ -177,6 +182,23 @@ class SearchQuery
     }
 
     /**
+     * Sets the raw 'boosts' attribute so that dynamic boosting can be applied with the search query rather than hard set
+     * in the elastic dashboard. This is useful where multiple search pages need to order results differently.
+     *
+     * See the docs for help:
+     * https://swiftype.com/documentation/app-search/api/search/boosts
+     *
+     * @param stdClass $boosts
+     * @return $this
+     */
+
+    public function addRawBoosts(stdClass $boosts): self
+    {
+        $this->rawBoosts = $boosts;
+        return $this;
+    }
+
+    /**
      * Add a sort method to the list, see:
      * https://www.elastic.co/guide/en/app-search/current/sort.html
      *
@@ -255,6 +277,10 @@ class SearchQuery
 
         if (isset($this->rawFacets)) {
             $query['facets'] = $this->rawFacets;
+        }
+
+        if (isset($this->rawBoosts)) {
+            $query['boosts'] = $this->rawBoosts;
         }
 
         if (isset($this->sort)) {


### PR DESCRIPTION
# Description
On a project we have multiple types of search pages for listing a result type, and on one of them we wanted the results ordered very specifically. For this page only we wanted to apply boosts on a certain field, so setting a boost in the elastic dashboard didn't give us what we needed.

The Elastic App Search API allows you to pass in boost configurations as part of the search. These changes update the SearchQuery so that boosts can be defined in this way.

- [ ] TODO: Add some unit tests to Search Query for the new boost config.
- [ ] Update documentation